### PR TITLE
Fix issue #446: stbbtt__hheap_free fails if heap has more than one chunk

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2395,7 +2395,7 @@ static void *stbtt__hheap_alloc(stbtt__hheap *hh, size_t size, void *userdata)
          hh->num_remaining_in_head_chunk = count;
       }
       --hh->num_remaining_in_head_chunk;
-      return (char *) (hh->head) + size * hh->num_remaining_in_head_chunk;
+      return (char *) (hh->head) + sizeof(stbtt__hheap_chunk) + size * hh->num_remaining_in_head_chunk;
    }
 }
 


### PR DESCRIPTION
I had the same problem that the person who report the issue, and implementing the proposed fix solved my problem.
As it seems to be a serious bug (despite it doesn't arise unless you have a very complicated font), I think that this fix should be integrated in the official repo.